### PR TITLE
Fix: #738

### DIFF
--- a/Photo Club Hub/View/MemberPortfoliosView/MemberPortfolioView.swift
+++ b/Photo Club Hub/View/MemberPortfoliosView/MemberPortfolioView.swift
@@ -151,11 +151,11 @@ struct MemberPortfolioView: View {
 
             }
         }
-        .searchable(text: $searchText, placement: .automatic,
+        .searchable(text: $searchText, placement: searchPlacement,
                     // .automatic
-                    // .toolbar The search field is placed in the toolbar. To right of person.text.rect.cust
-                    // .sidebar The search field is placed in the sidebar of a navigation view. not on iPad
-                    // .navigationBarDrawer The search field is placed in an drawer of the navigation bar. OK
+                    // .toolbar - The search field is placed in the toolbar. To right of person.text.rect.cust
+                    // .sidebar - The search field is placed in the sidebar of a navigation view. Not on iPad
+                    // .navigationBarDrawer - The search field is placed in an drawer of the navigation bar. OK
                     prompt: Text("Search_names_m",
                                  tableName: "PhotoClubHub.SwiftUI",
                                  comment: """
@@ -163,17 +163,33 @@ struct MemberPortfolioView: View {
                                           filter the members based on either given- and family name.
                                           """
                                 ))
-        .disableAutocorrection(true)
         .searchToolbarBehaviorIfAvailable()
+        .disableAutocorrection(true)
     }
 
 }
 
+// MARK: - Controlling search bar placement
+
+/// On iOS 27, `.automatic` + `.minimize` adds a duplicate nav-bar icon.
+/// While `.toolbar` + no `.minimize` suppresses it and gives the same single compact bottom button as iOS 26.
+private var searchPlacement: SearchFieldPlacement {
+    if #available(iOS 27, *) {
+        return .toolbar
+    } else {
+        return .automatic
+    }
+}
+
 private extension View {
-    /// Applies `.searchToolbarBehavior(.minimize)` on iOS 26+; no-op on earlier versions.
+    /// Applies `.searchToolbarBehavior(.minimize)` on iOS 26 only.
+    /// On iOS 27+, `.minimize` adds a duplicate nav-bar icon in addition to the compact bottom button;
+    /// using `.toolbar` placement without `.minimize` reproduces the iOS 26 single-button behavior instead.
     @ViewBuilder
     func searchToolbarBehaviorIfAvailable() -> some View {
-        if #available(iOS 26, *) {
+        if #available(iOS 27, *) {
+            self // Swift UI bug (FB23003932): .minimize displays 2 search icons
+        } else if #available(iOS 26, *) {
             self.searchToolbarBehavior(.minimize)
         } else {
             self

--- a/Photo Club Hub/View/OrganizationsView/OrganizationView.swift
+++ b/Photo Club Hub/View/OrganizationsView/OrganizationView.swift
@@ -86,7 +86,7 @@ struct OrganizationView: View {
             // remember that nothing will run here until the for try await loop finishes
         }
         .navigationTitle(modelToHoldPreferences.preferences.organizationLabel())
-        .searchable(text: $searchText, placement: .automatic,
+        .searchable(text: $searchText, placement: searchPlacement,
                     // .automatic
                     // .toolbar The search field is placed in the toolbar. To right of person.text.rect.cust
                     // .sidebar The search field is placed in the sidebar of a navigation view. not on iPad
@@ -98,7 +98,7 @@ struct OrganizationView: View {
                                           filter the members based on a fragment of the organization name or town.
                                           """
                                 ))
-        // .searchToolbarBehavior(.minimize) // requires iOS 26+
+        .searchToolbarBehaviorIfAvailable()
         .autocapitalization(.sentences)
         .disableAutocorrection(true)
     }
@@ -115,6 +115,34 @@ struct NoClubsText: View {
              """,
              tableName: "PhotoClubHub.SwiftUI",
              comment: "Hint to the user if the database returns zero Organizations.")
+    }
+}
+
+// MARK: - Controlling search bar placement
+
+/// On iOS 27, `.automatic` + `.minimize` adds a duplicate nav-bar icon.
+/// While `.toolbar` + no `.minimize` suppresses it and gives the same single compact bottom button as iOS 26.
+private var searchPlacement: SearchFieldPlacement {
+    if #available(iOS 27, *) {
+        return .toolbar
+    } else {
+        return .automatic
+    }
+}
+
+private extension View {
+    /// Applies `.searchToolbarBehavior(.minimize)` on iOS 26 only.
+    /// On iOS 27+, `.minimize` adds a duplicate nav-bar icon in addition to the compact bottom button;
+    /// using `.toolbar` placement without `.minimize` reproduces the iOS 26 single-button behavior instead.
+    @ViewBuilder
+    func searchToolbarBehaviorIfAvailable() -> some View {
+        if #available(iOS 27, *) {
+            self // Swift UI bug (FB23003932): .minimize displays 2 search icons
+        } else if #available(iOS 26, *) {
+            self.searchToolbarBehavior(.minimize)
+        } else {
+            self
+        }
     }
 }
 

--- a/Photo Club Hub/View/PhotographersView/PhotographersListView2626.swift
+++ b/Photo Club Hub/View/PhotographersView/PhotographersListView2626.swift
@@ -114,7 +114,7 @@ struct PhotographersListView2626: View {
         .autocapitalization(.sentences)
         .submitLabel(.done) // currently only works with text fields?
         .navigationTitle(navigationTitle)
-        .searchable(text: searchText, placement: .automatic,
+        .searchable(text: searchText, placement: searchPlacement,
                     prompt: Text("Search_names_p",
                                  tableName: "PhotoClubHub.SwiftUI",
                                  comment: """
@@ -122,7 +122,7 @@ struct PhotographersListView2626: View {
                                           filter the photographers based on either given- and family name.
                                           """)
         )
-        .searchToolbarBehavior(.minimize)
+        .searchToolbarBehaviorIfAvailable()
         .disableAutocorrection(true)
     }
 
@@ -136,6 +136,33 @@ struct PhotographersListView2626: View {
         return isSupported ? Self.iconExamples.supported.icon : Self.iconExamples.temporary.icon
     }
 
+}
+
+// MARK: - Controlling search bar placement
+
+/// On iOS 27, `.automatic` + `.minimize` adds a duplicate nav-bar icon.
+/// While `.toolbar` + no `.minimize` suppresses it and gives the same single compact bottom button as iOS 26.
+private var searchPlacement: SearchFieldPlacement {
+    if #available(iOS 27, *) {
+        return .toolbar
+    } else {
+        return .automatic
+    }
+}
+
+@available(iOS 26.0, *)
+private extension View {
+    /// Applies `.searchToolbarBehavior(.minimize)` on iOS 26 only.
+    /// On iOS 27+, `.minimize` adds a duplicate nav-bar icon on top of the compact bottom button;
+    /// using `.toolbar` placement without `.minimize` reproduces the iOS 26 single-button behavior instead.
+    @ViewBuilder
+    func searchToolbarBehaviorIfAvailable() -> some View {
+        if #available(iOS 27, *) {
+            self
+        } else {
+            self.searchToolbarBehavior(.minimize)
+        }
+    }
 }
 
 // MARK: - Previews


### PR DESCRIPTION
Dual search icons with iOS 27.0 beta 1.
Couldn't get a really clean fix, but managed to avoid having 2 icons.